### PR TITLE
Feat: 리뷰 많은 작품 순위 연동, 각종 수정

### DIFF
--- a/client/src/components/layout/CarouselSection.tsx
+++ b/client/src/components/layout/CarouselSection.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/carousel";
 import Autoplay from "embla-carousel-autoplay";
 import Tag from "@/components/Tag";
+import defaultImg from "@/assets/defaultImg.png";
 
 // 추후 수정
 interface RankingData {
@@ -94,42 +95,59 @@ export default function CarouselSection({ data }: { data: RankingData }) {
                   {slide.isTag ? (
                     /* 태그 레이아웃: 2열 그리드 */
                     <div className='flex-1 flex flex-col justify-between gap-[clamp(1rem,4vh,3rem)]'>
-                      {slide.items.slice(0, 5).map((tag, tIdx) => (
-                        <div
-                          key={tIdx}
-                          className='flex items-center gap-2 group'
-                        >
-                          <span className='text-[24px] font-bold text-white min-w-[25px]'>
-                            {tIdx + 1}.
-                          </span>
-                          <Tag
-                            label={tag.name}
-                            type={tag.type}
-                            isSelected={false}
-                          />
-                        </div>
-                      ))}
+                      {slide.items.length === 0 ? (
+                        <p className='text-white text-center mt-8'>
+                          데이터가 없습니다.
+                        </p>
+                      ) : (
+                        slide.items?.slice(0, 5).map((tag, tIdx) => (
+                          <div
+                            key={tIdx}
+                            className='flex items-center gap-2 group'
+                          >
+                            <span className='text-[24px] font-bold text-white min-w-[25px]'>
+                              {tIdx + 1}.
+                            </span>
+                            <Tag
+                              label={tag.name}
+                              type={tag.type}
+                              isSelected={false}
+                            />
+                          </div>
+                        ))
+                      )}
                     </div>
                   ) : (
                     /* 작품 레이아웃: 5개 배치 */
                     <div className='flex flex-col gap-3'>
-                      {slide.items.slice(0, 5).map((movie, mIdx) => (
-                        <div key={mIdx} className='flex items-center gap-2'>
-                          <span className='text-[24px] font-bold text-white min-w-[25px]'>
-                            {mIdx + 1}.
-                          </span>
-                          <div className='w-12 aspect-[3/4] rounded-md overflow-hidden shadow-sm bg-black/5 flex-shrink-0'>
-                            <img
-                              src={movie.posterPath}
-                              alt={movie.title}
-                              className='w-full h-full object-cover'
-                            />
+                      {slide.items.length === 0 ? (
+                        <p className='text-white text-center mt-8'>
+                          데이터가 없습니다.
+                        </p>
+                      ) : (
+                        slide.items?.slice(0, 5).map((movie, mIdx) => (
+                          <div key={mIdx} className='flex items-center gap-2'>
+                            <span className='text-[24px] font-bold text-white min-w-[25px]'>
+                              {mIdx + 1}.
+                            </span>
+                            <div className='w-12 aspect-[3/4] rounded-md overflow-hidden shadow-sm bg-black/5 flex-shrink-0'>
+                              <img
+                                src={movie.posterPath || defaultImg}
+                                alt={movie.title}
+                                className='w-full h-full object-cover'
+                                onError={(e) => {
+                                  // 데이터는 있는데 URL이 깨졌거나 이미지 서버 에러일 때
+                                  (e.currentTarget as HTMLImageElement).src =
+                                    defaultImg;
+                                }}
+                              />
+                            </div>
+                            <p className='flex-1 text-[14px] font-semibold text-white line-clamp-1 pr-2 leading-tight'>
+                              {movie.title}
+                            </p>
                           </div>
-                          <p className='flex-1 text-[14px] font-semibold text-white line-clamp-1 pr-2 leading-tight'>
-                            {movie.title}
-                          </p>
-                        </div>
-                      ))}
+                        ))
+                      )}
                     </div>
                   )}
                 </div>

--- a/client/src/components/review/WriteStep.tsx
+++ b/client/src/components/review/WriteStep.tsx
@@ -20,13 +20,15 @@ export default function WriteStep({
   const [currentMode, setCurrentMode] = useState(mode);
   const loginUserId = useAuthStore((state) => state.userId);
 
+  const today = new Date().toISOString().split("T")[0]; // yyyy-MM-dd 형식 오늘 날짜
+
   // 폼데이터 초기화
   const [formData, setFormData] = useState({
     title: "",
     score: 0.0,
     content: "",
-    watch_date: "",
-    write_date: "",
+    watch_date: today,
+    write_date: today,
     type: "movie",
     posterPath: "",
     tags: [] as string[],
@@ -104,7 +106,7 @@ export default function WriteStep({
   // 폼 검증 및 제출 함수
   const validateAndSubmit = () => {
     const newErrors = {
-      watch_date: !formData.watch_date,
+      watch_date: !formData.watch_date || formData.watch_date > today,
       tags: formData.tags.length === 0,
       content: !formData.content.trim(),
     };
@@ -180,6 +182,7 @@ export default function WriteStep({
                     type='date'
                     placeholder='yyyy-MM-dd'
                     value={formData.watch_date}
+                    max={today}
                     onChange={(e) => {
                       setFormData({ ...formData, watch_date: e.target.value });
                       setErrors({ ...errors, watch_date: false });
@@ -196,7 +199,7 @@ export default function WriteStep({
               )}
               {!isView && !!errors.watch_date && (
                 <p className='text-[14px] text-destructive'>
-                  관람일자를 입력해 주세요.
+                  관람일자를 올바르게 입력해 주세요.
                 </p>
               )}
             </div>

--- a/client/src/pages/Withdraw.tsx
+++ b/client/src/pages/Withdraw.tsx
@@ -73,6 +73,13 @@ export default function Withdraw() {
             <p className='text-[14px] text-dark-gray text-center'>
               본인 확인을 위해 비밀번호를 입력해 주세요.
             </p>
+            {/* 브라우저 경고 방지를 위한 숨겨진 input */}
+            <input
+              type='text'
+              name='username'
+              autoComplete='username'
+              style={{ display: "none" }}
+            />
             <Input
               type='password'
               placeholder='현재 비밀번호'

--- a/client/src/services/ranking.ts
+++ b/client/src/services/ranking.ts
@@ -1,25 +1,19 @@
 import API from "@/services/api";
-import defaultImg from "@/assets/defaultImg.png";
 
 export const getRankings = async () => {
   try {
     // 추후 추가 예정
-    const [movieRes, bookRes] = await Promise.all([
+    const [movieRes, bookRes, rankRes] = await Promise.all([
       API.get("/movie/ranking"),
       API.get("/book/ranking"),
+      API.get("/reviews/rank/most-reviewed"),
     ]);
 
     return {
       nowPlaying: movieRes.data,
       bestSellers: bookRes.data,
       // 아직 API 없는 순위는 더미로 유지
-      mostReviewed: [
-        { id: 1, title: "영화 A", posterPath: defaultImg },
-        { id: 2, title: "영화 B", posterPath: defaultImg },
-        { id: 3, title: "영화 C", posterPath: defaultImg },
-        { id: 4, title: "영화 D", posterPath: defaultImg },
-        { id: 5, title: "영화 E", posterPath: defaultImg },
-      ],
+      mostReviewed: rankRes.data,
       popularTags: [
         { name: "SF", type: "genre" },
         { name: "잔잔한", type: "mood" },

--- a/client/src/services/review.ts
+++ b/client/src/services/review.ts
@@ -56,7 +56,7 @@ export const getMyReviews = async ({
   type,
   tags,
 }: GetMyReviewsParams) => {
-  const { data } = await API.get("/auth/me/reviews", {
+  const { data } = await API.get("/reviews/me", {
     params: {
       page,
       size: 10,

--- a/server/routes/reviewRoutes.js
+++ b/server/routes/reviewRoutes.js
@@ -10,14 +10,17 @@ const authMiddleware = require("../middleware/authMiddleware");
 */
 router.use(authMiddleware);
 
+// 내가 쓴 리뷰 조회
+router.get("/reviews/me", reviewController.getMyReviews);
+
+// 가장 리뷰 많은 작품 순위 상위 5개
+router.get("/reviews/rank/most-reviewed", reviewController.getTopReviewed);
+
 // 전체 조회
 router.get("/reviews", reviewController.getReviewList);
 
 // 상세 조회
 router.get("/reviews/:id", reviewController.getReviewById);
-
-// 내가 쓴 리뷰 조회
-router.get("/reviews/me", reviewController.getMyReviews);
 
 // 리뷰 생성
 router.post("/reviews", reviewController.postReview);
@@ -27,8 +30,5 @@ router.put("/reviews/:id", reviewController.putReview);
 
 // 리뷰 삭제
 router.delete("/reviews/:id", reviewController.deleteReview);
-
-// 가장 리뷰 많은 작품 순위 상위 5개
-router.get("/reviews/rank/most-reviewed", reviewController.getTopReviewed);
 
 module.exports = router;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

<!-- ex) #이슈번호, close #이슈번호 (없으면 기재 X) -->
#18 

## 📝 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명 -->
- 리뷰 많은 작품 순위 연동
- 내 리뷰 조회 API URL 수정 연동
- 관람일자에 미래 날짜 입력 못하도록 방어로직 추가
- BE 라우터 고정 경로가 위로 오도록 순서 변경

### 스크린샷 (선택)
<img width="367" height="582" alt="image" src="https://github.com/user-attachments/assets/8b7a0286-d598-4257-8242-73fd9e9b4f46" />


## 💬 리뷰 요구사항 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분 -->
BE 라우터 고정경로가 변수경로나 보다 폭넓은 경로보다 상단에 위치하도록!
